### PR TITLE
Add migration session and log models

### DIFF
--- a/prisma/migrations/20260503231618_add_migration_models/migration.sql
+++ b/prisma/migrations/20260503231618_add_migration_models/migration.sql
@@ -1,0 +1,77 @@
+-- CreateEnum
+CREATE TYPE "MigrationSessionStatus" AS ENUM ('PENDING', 'CONFIRMED', 'FAILED', 'EXPIRED', 'CANCELLED');
+
+-- CreateEnum
+CREATE TYPE "MigrationSourceSoftware" AS ENUM ('QUICKBOOKS', 'WAVE', 'FRESHBOOKS', 'XERO', 'SAGE', 'OTHER');
+
+-- CreateTable
+CREATE TABLE "Customer" (
+    "id" TEXT NOT NULL,
+    "businessId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT,
+    "phone" TEXT,
+    "address" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Customer_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MigrationSession" (
+    "id" TEXT NOT NULL,
+    "businessId" TEXT NOT NULL,
+    "createdByUserId" TEXT NOT NULL,
+    "sourceSoftware" "MigrationSourceSoftware",
+    "originalFileName" TEXT,
+    "originalFileType" TEXT,
+    "originalFileSize" INTEGER,
+    "status" "MigrationSessionStatus" NOT NULL DEFAULT 'PENDING',
+    "parsedData" JSONB NOT NULL,
+    "previewSummary" JSONB,
+    "skippedDetails" JSONB,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "confirmedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MigrationSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MigrationLog" (
+    "id" TEXT NOT NULL,
+    "migrationSessionId" TEXT NOT NULL,
+    "businessId" TEXT NOT NULL,
+    "confirmedByUserId" TEXT NOT NULL,
+    "customersImported" INTEGER NOT NULL DEFAULT 0,
+    "invoicesImported" INTEGER NOT NULL DEFAULT 0,
+    "transactionsImported" INTEGER NOT NULL DEFAULT 0,
+    "recordsSkipped" INTEGER NOT NULL DEFAULT 0,
+    "skippedDetails" JSONB,
+    "completedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MigrationLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Customer_businessId_email_key" ON "Customer"("businessId", "email");
+
+-- AddForeignKey
+ALTER TABLE "Customer" ADD CONSTRAINT "Customer_businessId_fkey" FOREIGN KEY ("businessId") REFERENCES "Business"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MigrationSession" ADD CONSTRAINT "MigrationSession_businessId_fkey" FOREIGN KEY ("businessId") REFERENCES "Business"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MigrationSession" ADD CONSTRAINT "MigrationSession_createdByUserId_fkey" FOREIGN KEY ("createdByUserId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MigrationLog" ADD CONSTRAINT "MigrationLog_migrationSessionId_fkey" FOREIGN KEY ("migrationSessionId") REFERENCES "MigrationSession"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MigrationLog" ADD CONSTRAINT "MigrationLog_businessId_fkey" FOREIGN KEY ("businessId") REFERENCES "Business"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MigrationLog" ADD CONSTRAINT "MigrationLog_confirmedByUserId_fkey" FOREIGN KEY ("confirmedByUserId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,6 +14,9 @@ model User {
   createdAt  DateTime @default(now())
 
   business Business?
+
+  createdMigrationSessions MigrationSession[] @relation("MigrationSessionCreatedBy")
+  confirmedMigrationLogs   MigrationLog[]     @relation("MigrationLogConfirmedBy")
 }
 
 model Business {
@@ -24,11 +27,14 @@ model Business {
   gstRegistered Boolean
   createdAt     DateTime @default(now())
 
-  user            User              @relation(fields: [userId], references: [id])
-  snapshot        OpeningSnapshot?
-  transactions    Transaction[]
-  auditLogs       AuditLog[]
-  ReportingPeriod ReportingPeriod[]
+  user              User               @relation(fields: [userId], references: [id])
+  snapshot          OpeningSnapshot?
+  transactions      Transaction[]
+  auditLogs         AuditLog[]
+  reportingPeriods  ReportingPeriod[]
+  customers         Customer[]
+  migrationSessions MigrationSession[]
+  migrationLogs     MigrationLog[]
 }
 
 model OpeningSnapshot {
@@ -65,6 +71,23 @@ model Transaction {
   business Business @relation(fields: [businessId], references: [id])
 }
 
+model Customer {
+  id         String @id @default(uuid())
+  businessId String
+
+  name    String
+  email   String?
+  phone   String?
+  address String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  business Business @relation(fields: [businessId], references: [id])
+
+  @@unique([businessId, email])
+}
+
 model AuditLog {
   id         String   @id @default(uuid())
   businessId String
@@ -92,6 +115,54 @@ model ReportingPeriod {
   @@unique([businessId, startDate, endDate])
 }
 
+model MigrationSession {
+  id String @id @default(uuid())
+
+  businessId      String
+  createdByUserId String
+
+  sourceSoftware   MigrationSourceSoftware?
+  originalFileName String?
+  originalFileType String?
+  originalFileSize Int?
+
+  status MigrationSessionStatus @default(PENDING)
+
+  parsedData     Json
+  previewSummary Json?
+  skippedDetails Json?
+
+  expiresAt   DateTime
+  confirmedAt DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  business      Business @relation(fields: [businessId], references: [id])
+  createdByUser User     @relation("MigrationSessionCreatedBy", fields: [createdByUserId], references: [id])
+
+  logs MigrationLog[]
+}
+
+model MigrationLog {
+  id String @id @default(uuid())
+
+  migrationSessionId String
+  businessId         String
+  confirmedByUserId  String
+
+  customersImported    Int @default(0)
+  invoicesImported     Int @default(0)
+  transactionsImported Int @default(0)
+  recordsSkipped       Int @default(0)
+
+  skippedDetails Json?
+  completedAt    DateTime @default(now())
+
+  migrationSession MigrationSession @relation(fields: [migrationSessionId], references: [id])
+  business         Business         @relation(fields: [businessId], references: [id])
+  confirmedByUser  User             @relation("MigrationLogConfirmedBy", fields: [confirmedByUserId], references: [id])
+}
+
 enum PeriodType {
   MONTHLY
   QUARTERLY
@@ -107,4 +178,21 @@ enum TransactionSource {
   MANUAL
   AI
   UPLOAD
+}
+
+enum MigrationSessionStatus {
+  PENDING
+  CONFIRMED
+  FAILED
+  EXPIRED
+  CANCELLED
+}
+
+enum MigrationSourceSoftware {
+  QUICKBOOKS
+  WAVE
+  FRESHBOOKS
+  XERO
+  SAGE
+  OTHER
 }


### PR DESCRIPTION
## Summary
Adds the database foundation for Migration V1.

## Changes
- Added Customer model scoped by businessId
- Added MigrationSession model
- Added MigrationLog model
- Added MigrationSessionStatus enum
- Added MigrationSourceSoftware enum
- Added migration relations to User and Business
- Renamed Business reporting period relation for cleaner Prisma naming

## Testing
- Ran Prisma migration
- Ran Prisma format
- Ran npm run build

Closes #1